### PR TITLE
Model training device flag

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -65,6 +65,7 @@ def main():
     model_args = parser.add_argument_group("model arguments")
     parser.add_argument('--pretrained_model', required=False, default='cyto', type=str, help='model to use')
     parser.add_argument('--unet', required=False, default=0, type=int, help='run standard unet instead of cellpose flow output')
+    parser.add_argument('--device', required=False, default=None, type=int, help='CUDA Device to use')
     model_args.add_argument('--nclasses',default=3, type=int, help='if running unet, choose 2 or 3; if training omni, choose 4; standard Cellpose uses 3')
 
 
@@ -176,7 +177,7 @@ def main():
                     exit()
                     
                     
-        device, gpu = models.assign_device((not args.mxnet), args.use_gpu)
+        device, gpu = models.assign_device((not args.mxnet), args.use_gpu, gpu_number=args.device)
 
         #define available model names, right now we have three broad categories 
         model_names = ['cyto','nuclei','bact','cyto2','bact_omni','cyto2_omni']
@@ -391,7 +392,8 @@ def main():
                                         style_on=args.style_on,
                                         concatenation=args.concatenation,
                                         nclasses=args.nclasses,
-                                        nchan=nchan)
+                                        nchan=nchan,
+                                        gpu_number=args.device)
             else:
                 model = models.CellposeModel(device=device,
                                             torch=(not args.mxnet),

--- a/cellpose/core.py
+++ b/cellpose/core.py
@@ -81,10 +81,11 @@ def _use_gpu_torch(gpu_number=0):
 
 def assign_device(istorch, gpu, gpu_number=None):
     if gpu and use_gpu(istorch=istorch):
-        try:
-            torch_GPU = torch.device(f'cuda:{gpu_number}')
-        except: 
-            torch_GPU = torch.device(f'cuda')
+        if istorch:
+            try:
+                torch_GPU = torch.device(f'cuda:{gpu_number}')
+            except: 
+                torch_GPU = torch.device(f'cuda')
         device = torch_GPU if istorch else mx_GPU
         gpu=True
         core_logger.info('>>>> using GPU')

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -66,12 +66,12 @@ class Cellpose():
         run model using torch if available
 
     """
-    def __init__(self, gpu=False, model_type='cyto', net_avg=True, device=None, torch=True, model_dir=None, omni=False):
+    def __init__(self, gpu=False, model_type='cyto', net_avg=True, device=None, ptorch=True, model_dir=None, omni=False):
         super(Cellpose, self).__init__()
-        if not torch:
+        if not ptorch:
             if not MXNET_ENABLED:
-                torch = True
-        self.torch = torch
+                ptorch = True
+        self.torch = ptorch
         
         # assign device (GPU or CPU)
         sdevice, gpu = assign_device(self.torch, gpu)
@@ -404,7 +404,7 @@ class CellposeModel(UnetModel):
         super().__init__(gpu=gpu, pretrained_model=False,
                          diam_mean=self.diam_mean, net_avg=net_avg, device=device,
                          residual_on=residual_on, style_on=style_on, concatenation=concatenation,
-                         nclasses=self.nclasses, torch=self.torch, nchan=nchan)
+                         nclasses=self.nclasses, ptorch=self.torch, nchan=nchan, gpu_number=device)
 
         self.unet = False
         self.pretrained_model = pretrained_model

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -66,12 +66,12 @@ class Cellpose():
         run model using torch if available
 
     """
-    def __init__(self, gpu=False, model_type='cyto', net_avg=True, device=None, ptorch=True, model_dir=None, omni=False):
+    def __init__(self, gpu=False, model_type='cyto', net_avg=True, device=None, use_torch=True, model_dir=None, omni=False):
         super(Cellpose, self).__init__()
-        if not ptorch:
+        if not use_torch:
             if not MXNET_ENABLED:
-                ptorch = True
-        self.torch = ptorch
+                use_torch = True
+        self.torch = use_torch
         
         # assign device (GPU or CPU)
         sdevice, gpu = assign_device(self.torch, gpu)
@@ -404,7 +404,7 @@ class CellposeModel(UnetModel):
         super().__init__(gpu=gpu, pretrained_model=False,
                          diam_mean=self.diam_mean, net_avg=net_avg, device=device,
                          residual_on=residual_on, style_on=style_on, concatenation=concatenation,
-                         nclasses=self.nclasses, ptorch=self.torch, nchan=nchan, gpu_number=device)
+                         nclasses=self.nclasses, use_torch=self.torch, nchan=nchan, gpu_number=device)
 
         self.unet = False
         self.pretrained_model = pretrained_model


### PR DESCRIPTION
Added a device flag for model training per #389

Few notes: 
- Refactored a few methods that used `torch` as an optional parameter name. This prevents using the torch import, so I changed them to `use_torch` to keep consistency with the other instances. 
- Added an argument to the cli arg parser in 
- I don't think this is a perfect implementation as we're still getting some GPU activity on torch device 0 regardless of the set device.